### PR TITLE
Clean apt cache and temp files to get a smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,7 @@ COPY all.conf /etc/supervisor/conf.d/
 EXPOSE 80
 COPY run.sh /
 
+# Clean to get a smaller image
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/
+
 CMD ["bash","/run.sh"]


### PR DESCRIPTION
Add

RUN apt-get clean && rm -rf /var/lib/apt/lists/\* /tmp/\* /var/tmp/

To get a smaller image
