### PR TITLE
prevent error for libmariadbclient-dev not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /home/$FRAPPE_USER
 
 COPY setup.sh /
 RUN  bash /setup.sh
-RUN apt-get -y remove build-essential python-dev python-software-properties libmariadbclient-dev libxslt1-dev libcrypto++-dev \
+RUN apt-get -y remove build-essential python-dev python-software-properties libxslt1-dev libcrypto++-dev \
 libssl-dev  && apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/ /home/$FRAPPE_USER/.cache
 
 


### PR DESCRIPTION
Hey there!

This is super freaking useful, so thank you. I'm pulling your scripts into my repo to make it easier to make changes to `erpnext`, and I noticed that it would throw this upon a `docker build -t .`

```
E: Unable to locate package libmariadbclient-dev
```

Removing `libmariadbclient-dev` has no negative impact on building the container as far as I know. Run your own test and see if that's the case! :+1: 
